### PR TITLE
prov/sockets: Add missing error return to sock_ep_enable

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1036,10 +1036,13 @@ int sock_ep_enable(struct fid_ep *ep)
 		}
 	}
 
-	if (sock_ep->attr->ep_type != FI_EP_MSG &&
-	    !sock_ep->attr->conn_handle.do_listen &&
-	    sock_conn_listen(sock_ep->attr))
-		SOCK_LOG_ERROR("cannot start connection thread\n");
+	if (sock_ep->attr->ep_type != FI_EP_MSG && !sock_ep->attr->conn_handle.do_listen) {
+		int ret = sock_conn_listen(sock_ep->attr);
+		if (ret) {
+			SOCK_LOG_ERROR("cannot start connection thread\n");
+			return ret;
+		}
+	}
 	sock_ep->attr->is_enabled = 1;
 	return 0;
 }


### PR DESCRIPTION
Signed-off-by: Ralf Juengling <ralfjuen@amazon.com>
(cherry picked from commit bb0bf66551f019d35b8c88db77d80e503d0d4b32)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
