### PR TITLE
Add cooldown to Dependabot config to mitigate supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Addresses zizmor finding #54 (insufficient-cooldown). Delays adoption of new releases by 7 days (14 for major bumps), giving time for compromised packages to be flagged before Dependabot proposes them. Security updates bypass the cooldown automatically.
